### PR TITLE
Update to use rockylinux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM centos:8
-
-ADD /installer/fspd.rpm /fspd.rpm
-RUN rpm -i fspd.rpm
+FROM rockylinux:9
+RUN dnf -y install wget chkconfig
+RUN wget -O /tmp/fspd.rpm https://sourceforge.net/projects/fsp/files/fsp/2.8.1b29/fspd-2.8.1b29-2.el7.x86_64.rpm/download
+RUN rpm -i /tmp/fspd.rpm
+RUN rm /tmp/fspd.rpm
 ENTRYPOINT ["fspd", "-X"]

--- a/installer/place-installer-here.txt
+++ b/installer/place-installer-here.txt
@@ -1,3 +1,0 @@
-Download here:
-https://sourceforge.net/projects/fsp/files/fsp/2.8.1b29/fspd-2.8.1b29-2.el7.x86_64.rpm/download
-and rename to fspd.rpm


### PR DESCRIPTION
Centos is deprecated, switch to rockylinux and also download the fspd rpm as part of the Dockerfile.