### PR TITLE
Use minimal rockylinux to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM rockylinux:9
-RUN dnf -y install wget chkconfig
-RUN wget -O /tmp/fspd.rpm https://sourceforge.net/projects/fsp/files/fsp/2.8.1b29/fspd-2.8.1b29-2.el7.x86_64.rpm/download
+FROM rockylinux:9-minimal
+RUN microdnf -y install wget chkconfig
+RUN wget -nv -O /tmp/fspd.rpm https://sourceforge.net/projects/fsp/files/fsp/2.8.1b29/fspd-2.8.1b29-2.el7.x86_64.rpm/download
 RUN rpm -i /tmp/fspd.rpm
 RUN rm /tmp/fspd.rpm
+RUN microdnf clean all
 ENTRYPOINT ["fspd", "-X"]


### PR DESCRIPTION
Sorry - me again! I realised I can reduce the image size quite a bit by using the minimal rockylinux base image.
(Also made the wget output quieter)